### PR TITLE
Fix: Quick fix for unsupported template literals

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,15 +1,14 @@
 #!/usr/bin/env node
 
-// TODO: Find out minimal version of Node, uncomment the version check.
-// const currentNodeVersion = process.versions.node;
-// const semver = currentNodeVersion.split(".");
-// const major = semver[0];
-//
-// if (major < x) {
-//   console.error(`You are running Node ${currentNodeVersion}.`);
-//   console.error("Please update your version of Node to 8 or higher.");
-//
-//   process.exit(1);
-// }
+const currentNodeVersion = process.versions.node;
+const semver = currentNodeVersion.split('.');
+const major = semver[0];
+
+if (major < 6) {
+  console.error('You are running Node ' + currentNodeVersion + '.');
+  console.error('Please update your version of Node to 6 or higher.');
+
+  process.exit(1);
+}
 
 require('./blogfoster-scripts');

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "lint": "eslint .",
     "format": "prettier --write './**/*.{js,json}'"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.1.2",


### PR DESCRIPTION
I've just caught a simple mistake in the (for now) commented version check for the script. 
When starting the script with node version below 4.x the `console.error`, logging the used version will fail since the engine does not support template literals.